### PR TITLE
feat: scope manifest to twitter and x domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,9 @@
 	"version": "1.2",
 	"description": "Redirects Twitter/X to Nitter for a private, ad-free experience.",
 	"permissions": [
-		"webNavigation"
+		"webNavigation",
+		"*://twitter.com/*",
+		"*://x.com/*"
 	],
 	"background": {
 		"scripts": ["background.js"],


### PR DESCRIPTION
Scoping the manifest allows the browser to automatically only activate the addon on those domains.

This reduces permissions, increases transparency and trust